### PR TITLE
:bug: fix(tmux): stop `unkown key` error on tmux startup

### DIFF
--- a/state/tmux/.tmux.conf
+++ b/state/tmux/.tmux.conf
@@ -28,7 +28,7 @@ bind-key -n M-< swap-window -t -1
 bind-key -n M-> swap-window -t +1
 bind-key -n M-X confirm-before "kill-window"
 bind-key -n M-- split-window -v -c "#{pane_current_path}"
-bind-key -n M-\ split-window -h -c "#{pane_current_path}"
+bind-key -n M-\\ split-window -h -c "#{pane_current_path}"
 bind-key -n M-v split-window -h -c "#{pane_current_path}"
 bind-key -n M-b split-window -v -c "#{pane_current_path}"
 bind-key -n M-R command-prompt -I "#W" "rename-window '%%'"


### PR DESCRIPTION
INCOMPATIBLE: tmux's configuration parsing has changed to use yacc(1). There
  is one incompatible change: a \ on its own must be escaped or quoted as
  either \\ or '\' (the latter works on older tmux versions).